### PR TITLE
SDKS-3476: DittoDotnetTools: Use .env file for SampleApp credentials configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Copy this file from ".env.sample" to ".env", then fill in these values
+# A Ditto AppID and Playground token can be obtained from https://portal.ditto.live
+DITTO_APP_ID=""
+DITTO_PLAYGROUND_TOKEN=""
+DITTO_AUTH_URL=""
+DITTO_WEBSOCKET_URL=""

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ project.lock.json
 *.pyc
 nupkg/
 
+# Local credentials
+.env
+
 # Visual Studio Code
 .vscode/
 

--- a/README.md
+++ b/README.md
@@ -162,5 +162,13 @@ heartbeat.StartHeartbeat(ditto, config, (heartbeatInfo) => {
 ## Ditto Tools Example App 
 
 
-The [Ditto Tools Example App](https://github.com/getditto/DittoDotnetTools/tree/main/SampleApp) included in this repo allows you to try the DittoDotnetTools in a standalone .NET MAUI app. 
+The [Ditto Tools Example App](https://github.com/getditto/DittoDotnetTools/tree/main/SampleApp) included in this repo allows you to try the DittoDotnetTools in a standalone .NET MAUI app.
+
+Before your first build, copy the credentials template and fill in your values from the [Ditto Portal](https://portal.ditto.live):
+
+```sh
+cp .env.sample .env
+```
+
+The `.env` file is embedded at build time and read at app startup. The app fails to launch if any required key is missing.
 

--- a/README.md
+++ b/README.md
@@ -164,13 +164,11 @@ heartbeat.StartHeartbeat(ditto, config, (heartbeatInfo) => {
 
 The [Ditto Tools Example App](https://github.com/getditto/DittoDotnetTools/tree/main/SampleApp) included in this repo allows you to try the DittoDotnetTools in a standalone .NET MAUI app.
 
-Before your first build, copy the credentials template and fill in your values from the [Ditto Portal](https://portal.ditto.live):
+Before your first build, copy `.env.sample` to `.env` at the repo root and fill in values from the [Ditto Portal](https://portal.ditto.live):
 
 ```sh
 cp .env.sample .env
 ```
 
-The four required keys are `DITTO_APP_ID`, `DITTO_PLAYGROUND_TOKEN`, `DITTO_AUTH_URL`, and `DITTO_WEBSOCKET_URL`.
-
-At build time, `SampleApp.csproj` embeds `.env` as a resource (`<EmbeddedResource Include="../.env" />`). At startup, `MauiProgram.LoadEnvVariables()` reads that resource stream and `SetupDitto()` wires the values into `DittoIdentity.OnlinePlayground(...)` and the WebSocket transport config. The app fails to launch with a clear error if the embedded resource is missing or any required key is empty.
+Required keys: `DITTO_APP_ID`, `DITTO_PLAYGROUND_TOKEN`, `DITTO_AUTH_URL`, `DITTO_WEBSOCKET_URL`. The app throws at launch if any are empty.
 

--- a/README.md
+++ b/README.md
@@ -170,5 +170,7 @@ Before your first build, copy the credentials template and fill in your values f
 cp .env.sample .env
 ```
 
-The `.env` file is embedded at build time and read at app startup. The app fails to launch if any required key is missing.
+The four required keys are `DITTO_APP_ID`, `DITTO_PLAYGROUND_TOKEN`, `DITTO_AUTH_URL`, and `DITTO_WEBSOCKET_URL`.
+
+At build time, `SampleApp.csproj` embeds `.env` as a resource (`<EmbeddedResource Include="../.env" />`). At startup, `MauiProgram.LoadEnvVariables()` reads that resource stream and `SetupDitto()` wires the values into `DittoIdentity.OnlinePlayground(...)` and the WebSocket transport config. The app fails to launch with a clear error if the embedded resource is missing or any required key is empty.
 

--- a/SampleApp/MauiProgram.cs
+++ b/SampleApp/MauiProgram.cs
@@ -1,4 +1,5 @@
-﻿using DittoSDK;
+using System.Reflection;
+using DittoSDK;
 using Microsoft.Extensions.Logging;
 using SampleApp.Pages;
 
@@ -31,12 +32,85 @@ public static class MauiProgram
 
     private static Ditto SetupDitto()
     {
-        var id = DittoIdentity.OnlinePlayground("<APP_ID>", "<TOKEN>", false);
+        var envVars = LoadEnvVariables();
+        var appId = RequireEnv(envVars, "DITTO_APP_ID");
+        var playgroundToken = RequireEnv(envVars, "DITTO_PLAYGROUND_TOKEN");
+        var authUrl = RequireEnv(envVars, "DITTO_AUTH_URL");
+        var websocketUrl = RequireEnv(envVars, "DITTO_WEBSOCKET_URL");
 
-        var ditto = new Ditto(id);
+        var ditto = new Ditto(
+            DittoIdentity.OnlinePlayground(appId, playgroundToken, false, authUrl),
+            Path.Combine(FileSystem.Current.AppDataDirectory, "ditto"));
+
+        ditto.UpdateTransportConfig(config =>
+        {
+            config.Connect.WebsocketUrls.Add(websocketUrl);
+        });
+
         ditto.DisableSyncWithV3();
         ditto.StartSync();
 
         return ditto;
+    }
+
+    /// <summary>
+    /// Loads environment variables from the <c>.env</c> resource embedded at the repo root.
+    /// </summary>
+    private static Dictionary<string, string> LoadEnvVariables()
+    {
+        var envVars = new Dictionary<string, string>();
+        var assembly = Assembly.GetExecutingAssembly();
+        const string resourceName = "SampleApp..env";
+
+        using Stream? stream = assembly.GetManifestResourceStream(resourceName);
+        if (stream == null)
+        {
+            var availableResources = string.Join(Environment.NewLine, assembly.GetManifestResourceNames());
+            throw new InvalidOperationException(
+                $"Embedded resource '{resourceName}' not found. " +
+                "Copy .env.sample to .env at the repo root and fill in your values from https://portal.ditto.live. " +
+                $"Available resources:{Environment.NewLine}{availableResources}");
+        }
+
+        using var reader = new StreamReader(stream);
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+        {
+            line = line.Trim();
+
+            if (string.IsNullOrEmpty(line) || line.StartsWith("#"))
+            {
+                continue;
+            }
+
+            int separatorIndex = line.IndexOf('=');
+            if (separatorIndex < 0)
+            {
+                continue;
+            }
+
+            string key = line.Substring(0, separatorIndex).Trim();
+            string value = line.Substring(separatorIndex + 1).Trim();
+
+            if (value.Length >= 2 && value.StartsWith("\"") && value.EndsWith("\""))
+            {
+                value = value.Substring(1, value.Length - 2);
+            }
+
+            envVars[key] = value;
+        }
+
+        return envVars;
+    }
+
+    private static string RequireEnv(Dictionary<string, string> envVars, string key)
+    {
+        if (!envVars.TryGetValue(key, out var value) || string.IsNullOrEmpty(value))
+        {
+            throw new InvalidOperationException(
+                $"{key} not found in .env. " +
+                "Copy .env.sample to .env at the repo root and fill in your values from https://portal.ditto.live.");
+        }
+        return value;
     }
 }

--- a/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp.csproj
@@ -54,6 +54,9 @@
 
 		<!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
 		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
+
+		<!-- Credentials file at the repo root, embedded as a resource and parsed by MauiProgram. -->
+		<EmbeddedResource Include="../.env" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Makes the SampleApp read Ditto credentials from a `.env` file at the repo root, same way the [Quickstart apps](https://github.com/getditto/quickstart) do. A `.env` populated for any Quickstart works here too.

[SDKS-3476](https://linear.app/ditto/issue/SDKS-3476/dittodotnettools-use-env-file-for-sampleapp-credentials-configuration)

## Changes

- `SampleApp.csproj` embeds `../.env` as a MAUI resource.
- `MauiProgram` reads the embedded stream at startup (strips comments, blanks, surrounding quotes), wires the values into `DittoIdentity.OnlinePlayground` and the WebSocket transport config, and throws per-key if anything's missing.
- Drop the hardcoded `<APP_ID>` / `<TOKEN>` placeholders.