### PR TITLE
Migrate ditto.live links to ditto.com

### DIFF
--- a/DittoHeartbeat/DittoHeartbeat.csproj
+++ b/DittoHeartbeat/DittoHeartbeat.csproj
@@ -12,7 +12,7 @@
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PackageTags>Ditto;Sync;Edge;PeerToPeer;P2P;Mesh;MAUI;.NET;iOS;Android;Debug;Diagnostic;Tools;Heartbeat</PackageTags>
 		<PackageIcon>icon.png</PackageIcon>
-		<PackageProjectUrl>https://ditto.live</PackageProjectUrl>
+		<PackageProjectUrl>https://www.ditto.com</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/getditto/DittoDotnetTools</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<_DittoIncludeNativeAndroidLibs>False</_DittoIncludeNativeAndroidLibs>

--- a/DittoPresenceViewer/DittoPresenceViewer.csproj
+++ b/DittoPresenceViewer/DittoPresenceViewer.csproj
@@ -21,7 +21,7 @@
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PackageTags>Ditto;Sync;Edge;PeerToPeer;P2P;Mesh;MAUI;.NET;iOS;Android;Debug;Diagnostic;Tools;Presence;PresenceViewer</PackageTags>
 		<PackageIcon>icon.png</PackageIcon>
-		<PackageProjectUrl>https://ditto.live</PackageProjectUrl>
+		<PackageProjectUrl>https://www.ditto.com</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/getditto/DittoDotnetTools</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ditto .NET Tools are diagnostic tools for Ditto.
 
 These tools are available through NuGet. 
 
-For support, please contact Ditto Support (<support@ditto.live>).
+For support, please contact Ditto Support (<support@ditto.com>).
 
 ## Usage 
 


### PR DESCRIPTION
## Summary
- Updates README support contact from `support@ditto.live` to `support@ditto.com`.
- Updates `<PackageProjectUrl>` in DittoHeartbeat.csproj and DittoPresenceViewer.csproj from `https://ditto.live` to `https://www.ditto.com`.